### PR TITLE
Fix CSRF for projektanfrage form

### DIFF
--- a/app/zep_dummy_app/www/projektanfrage.html
+++ b/app/zep_dummy_app/www/projektanfrage.html
@@ -6,6 +6,7 @@
 <p>Vielen Dank für deine Anfrage.</p>
 {% else %}
 <form action="/projektanfrage" method="post" enctype="multipart/form-data">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
 <div class="form-group">
 <label for="auftragsart">Auftragsart</label>
 <select class="form-control" name="auftragsart" id="auftragsart" required>

--- a/app/zep_dummy_app/zep_dummy_app/www/projektanfrage.html
+++ b/app/zep_dummy_app/zep_dummy_app/www/projektanfrage.html
@@ -6,6 +6,7 @@
 <p>Vielen Dank für deine Anfrage.</p>
 {% else %}
 <form action="/projektanfrage" method="post" enctype="multipart/form-data">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
 <div class="form-group">
 <label for="auftragsart">Auftragsart</label>
 <select class="form-control" name="auftragsart" id="auftragsart" required>


### PR DESCRIPTION
## Summary
- add CSRF token input to Projektanfrage forms

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685cb9b022dc832aa8ae0f737dbecef4